### PR TITLE
fix(tests): use supported intrinsic procedures

### DIFF
--- a/src/emulated_intrinsics_interface.F90
+++ b/src/emulated_intrinsics_interface.F90
@@ -7,8 +7,10 @@
 module emulated_intrinsics_interface
   !! author: Damian Rouson
   !!
-  !! Emulations of some Fortran 2008 and 2018 instrinsic procedures for use with
-  !! compilers that lack support for the corresponding procedures.
+  !! This module contains two categories of procedures:
+  !! 1. Emulations of some Fortran 2008 and 2018 instrinsic procedures for use with
+  !!    compilers that lack support for the corresponding procedures.
+  !! 2. User-defined collective procedures not defined in the Fortran standard.
   implicit none
 
   interface

--- a/tests/single_image_intrinsics_test.F90
+++ b/tests/single_image_intrinsics_test.F90
@@ -6,7 +6,9 @@
 !
 module single_image_intrinsics_test
     use Vegetables, only: Result_t, Test_Item_t, describe, it, assert_equals
+#ifdef COMPILER_LACKS_FINDLOC
     use emulated_intrinsics_interface, only : findloc
+#endif
 
     implicit none
     private
@@ -93,4 +95,3 @@ contains
   end function
 
 end module
-


### PR DESCRIPTION
This enables the vegetables-generated test files to work whether
or not the emulated intrinsics are compiled.