### PR TITLE
refac(all): switch PODA "this" to "self"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Build directories
+build
+
 # Prerequisites
 *.d
 

--- a/src/co_object_implementation.f90
+++ b/src/co_object_implementation.f90
@@ -10,11 +10,11 @@ submodule(co_object_interface) co_object_implementation
 contains
 
     module procedure mark_as_defined
-      this%defined=.true.
+      self%defined=.true.
     end procedure
 
     module procedure user_defined
-      is_defined = this%defined
+      is_defined = self%defined
     end procedure
 
 end submodule

--- a/src/co_object_interface.f90
+++ b/src/co_object_interface.f90
@@ -11,7 +11,7 @@ module co_object_interface
   public :: co_object
 
   ! Define an abstract parent type to ensure basic functionality expected to be provided by all non-abstract types.
-  ! Each non-abstract type provides the functionality by extending this type and implementing its deferred binding(s).  This
+  ! Each non-abstract type provides the functionality by extending self type and implementing its deferred binding(s).  This
   ! type resembles java's Object class in the sense that it is intended to be the ultimate ancester of every other type.
   type, abstract :: co_object
     private
@@ -25,16 +25,16 @@ module co_object_interface
 
   interface
 
-    pure module subroutine mark_as_defined(this)
+    pure module subroutine mark_as_defined(self)
       !! Mark the co_object as user-defined
       implicit none
-      class(co_object), intent(inout) :: this
+      class(co_object), intent(inout) :: self
     end subroutine
 
-    pure module function user_defined(this) result(is_defined)
-      !! Return a boolean result indicating whether this co_object has been initialized since its declaration
+    pure module function user_defined(self) result(is_defined)
+      !! Return a boolean result indicating whether self co_object has been initialized since its declaration
       implicit none
-      class(co_object), intent(in) :: this
+      class(co_object), intent(in) :: self
       logical :: is_defined
     end function
 

--- a/src/object_implementation.f90
+++ b/src/object_implementation.f90
@@ -10,11 +10,11 @@ submodule(object_interface) object_implementation
 contains
 
     module procedure mark_as_defined
-      this%defined=.true.
+      self%defined=.true.
     end procedure
 
     module procedure user_defined
-      is_defined = this%defined
+      is_defined = self%defined
     end procedure
 
 end submodule

--- a/src/object_interface.f90
+++ b/src/object_interface.f90
@@ -18,7 +18,7 @@ module object_interface
     !! summary: Abstract type to ensure all objects extending it implement the required methods
     !!
     !! Define an abstract parent type to ensure basic functionality expected to be provided by all non-abstract types.
-    !! Each non-abstract type provides the functionality by extending this type and implementing its deferred binding(s).  This
+    !! Each non-abstract type provides the functionality by extending self type and implementing its deferred binding(s).  This
     !! type resembles java's Object class in the sense that it is intended to be the ultimate ancestor of every other type.
     private
     logical :: defined=.false.
@@ -32,16 +32,16 @@ module object_interface
 
   interface
 
-    pure module subroutine mark_as_defined(this)
+    pure module subroutine mark_as_defined(self)
       !! Mark the object as user-defined
       implicit none
-      class(object_t), intent(inout) :: this
+      class(object_t), intent(inout) :: self
     end subroutine
 
-    pure module function user_defined(this) result(is_defined)
-      !! Return a boolean result indicating whether this object has been initialized since its declaration
+    pure module function user_defined(self) result(is_defined)
+      !! Return a boolean result indicating whether self object has been initialized since its declaration
       implicit none
-      class(object_t), intent(in) :: this
+      class(object_t), intent(in) :: self
       logical :: is_defined
     end function
 

--- a/src/oracle_implementation.f90
+++ b/src/oracle_implementation.f90
@@ -7,7 +7,7 @@ contains
   module procedure within_tolerance
     class(oracle_t), allocatable :: error
 
-    error = this - reference
+    error = self - reference
     in_tolerance = (error%norm() <= tolerance)
 
   end procedure

--- a/src/oracle_interface.f90
+++ b/src/oracle_interface.f90
@@ -17,32 +17,32 @@ module oracle_interface
 
   abstract interface
 
-    function subtract_interface(this, rhs) result(difference)
-      !! result has components corresponding to subtracting rhs's components fron this object's components
+    function subtract_interface(self, rhs) result(difference)
+      !! result has components corresponding to subtracting rhs's components fron self object's components
       import oracle_t
       implicit none
-      class(oracle_t), intent(in) :: this, rhs
+      class(oracle_t), intent(in) :: self, rhs
       class(oracle_t), allocatable :: difference
     end function
 
-    pure function norm_interface(this) result(norm_of_this)
-      !! result is a norm of the array formed by concatenating the real components of this object
+    pure function norm_interface(self) result(norm_of_self)
+      !! result is a norm of the array formed by concatenating the real components of self object
       import oracle_t
       implicit none
-      class(oracle_t), intent(in) :: this
-      real norm_of_this
+      class(oracle_t), intent(in) :: self
+      real norm_of_self
     end function
 
   end interface
 
   interface
 
-    module function within_tolerance(this, reference, tolerance) result(in_tolerance)
-      !! template method with true result iff the difference in state vectors (this - reference) has a norm within tolerance
+    module function within_tolerance(self, reference, tolerance) result(in_tolerance)
+      !! template method with true result iff the difference in state vectors (self - reference) has a norm within tolerance
       !! (impure because of internal call to 'subtract' binding)
-      !! The existence of this procedure eliminates the need to rewrite similar code for every oracle child type.
+      !! The existence of self procedure eliminates the need to rewrite similar code for every oracle child type.
       implicit none
-      class(oracle_t), intent(in) :: this, reference
+      class(oracle_t), intent(in) :: self, reference
       real, intent(in) :: tolerance
       logical in_tolerance
     end function


### PR DESCRIPTION
This pull request changes every passed-object dummy argument (PODA) from C++-like `this` to Python-like `self` because more new Fortran programmers with object-oriented programming experience are coming from Python rather than C++ these days.