### PR TITLE
refac: change (sub)module name suffixes {interface,implementation}->{m,s}

### DIFF
--- a/src/array_functions_m.f90
+++ b/src/array_functions_m.f90
@@ -4,7 +4,7 @@
 !     "Multi-Dimensional Physics Implementation into Fuel Analysis under Steady-state and Transients (FAST)",
 !     contract # NRC-HQ-60-17-C-0007
 !
-module array_functions_interface
+module array_functions_m
   !! author: Damian Rouson
   !! date: 04/25/2019
   !!

--- a/src/array_functions_s.f90
+++ b/src/array_functions_s.f90
@@ -4,7 +4,7 @@
 !     "Multi-Dimensional Physics Implementation into Fuel Analysis under Steady-state and Transients (FAST)",
 !     contract # NRC-HQ-60-17-C-0007
 !
-submodule(array_functions_interface) array_functions_implementation
+submodule(array_functions_m) array_functions_s
   use assert_m, only : assert
   implicit none
 contains

--- a/src/co_object_implementation.f90
+++ b/src/co_object_implementation.f90
@@ -4,7 +4,7 @@
 !     "Multi-Dimensional Physics Implementation into Fuel Analysis under Steady-state and Transients (FAST)",
 !     contract # NRC-HQ-60-17-C-0007
 !
-submodule(co_object_interface) co_object_implementation
+submodule(co_object_m) co_object_s
   implicit none
 
 contains

--- a/src/co_object_m.f90
+++ b/src/co_object_m.f90
@@ -4,7 +4,7 @@
 !     "Multi-Dimensional Physics Implementation into Fuel Analysis under Steady-state and Transients (FAST)",
 !     contract # NRC-HQ-60-17-C-0007
 !
-module co_object_interface
+module co_object_m
   implicit none
 
   private
@@ -40,4 +40,4 @@ module co_object_interface
 
   end interface
 
-end module co_object_interface
+end module co_object_m

--- a/src/command_line_m.f90
+++ b/src/command_line_m.f90
@@ -1,4 +1,4 @@
-module command_line_interface
+module command_line_m
   !! return command line argument information
   implicit none
 

--- a/src/command_line_s.f90
+++ b/src/command_line_s.f90
@@ -1,4 +1,4 @@
-submodule(command_line_interface) command_line_implementation
+submodule(command_line_m) command_line_s
   implicit none
 
 contains

--- a/src/data_partition_m.f90
+++ b/src/data_partition_m.f90
@@ -1,4 +1,4 @@
-module data_partition_interface
+module data_partition_m
   !! distribute data identification numbers across images such that the number of
   !! items differs by at most 1 between any two images.
   use iso_fortran_env, only : real32, real64
@@ -75,4 +75,4 @@ module data_partition_interface
 
   end interface
 
-end module data_partition_interface
+end module data_partition_m

--- a/src/data_partition_s.f90
+++ b/src/data_partition_s.f90
@@ -1,4 +1,4 @@
-submodule(data_partition_interface) data_partition_implementation
+submodule(data_partition_m) data_partition_s
   use assert_m, only : assert
   implicit none
 
@@ -242,4 +242,4 @@ contains
     end associate
   end procedure
 
-end submodule data_partition_implementation
+end submodule data_partition_s

--- a/src/object_m.f90
+++ b/src/object_m.f90
@@ -6,7 +6,7 @@
 !     "Multi-Dimensional Physics Implementation into Fuel Analysis under Steady-state and Transients (FAST)",
 !     contract # NRC-HQ-60-17-C-0007
 !     ```
-module object_interface
+module object_m
   implicit none
 
   private
@@ -60,4 +60,4 @@ module object_interface
     end subroutine
   end interface
 
-end module object_interface
+end module object_m

--- a/src/object_s.f90
+++ b/src/object_s.f90
@@ -4,7 +4,7 @@
 !     "Multi-Dimensional Physics Implementation into Fuel Analysis under Steady-state and Transients (FAST)",
 !     contract # NRC-HQ-60-17-C-0007
 !
-submodule(object_interface) object_implementation
+submodule(object_m) object_s
   implicit none
 
 contains

--- a/src/oracle_m.f90
+++ b/src/oracle_m.f90
@@ -1,6 +1,6 @@
-module oracle_interface
+module oracle_m
   !! verify actual output against expected
-  use object_interface, only : object_t
+  use object_m, only : object_t
   implicit none
 
   private

--- a/src/oracle_s.f90
+++ b/src/oracle_s.f90
@@ -1,5 +1,5 @@
-submodule(oracle_interface) oracle_implementation
-  !! define procedures corresponding to the interface bodies in oracle_interface
+submodule(oracle_m) oracle_s
+  !! define procedures corresponding to the interface bodies in oracle_m
   implicit none
 
 contains
@@ -12,4 +12,4 @@ contains
 
   end procedure
 
-end submodule oracle_implementation
+end submodule oracle_s

--- a/src/string_functions_m.f90
+++ b/src/string_functions_m.f90
@@ -4,16 +4,14 @@
 !     "Multi-Dimensional Physics Implementation into Fuel Analysis under Steady-state and Transients (FAST)",
 !     contract # NRC-HQ-60-17-C-0007
 !
-module string_functions_interface
+module string_functions_m
   !! author: Damian Rouson
   !! date: August 23, 2019
   !! summary: utilities for manipulating or producing character variables
   implicit none
 
   private
-  public :: file_extension, csv_format, base_name, string
-
-  character(len=*), parameter :: csv_format = '(*(G0,:,","))'
+  public :: file_extension, base_name, string
 
   interface string
     module procedure integer_to_string

--- a/src/string_functions_s.f90
+++ b/src/string_functions_s.f90
@@ -4,7 +4,7 @@
 !     "Multi-Dimensional Physics Implementation into Fuel Analysis under Steady-state and Transients (FAST)",
 !     contract # NRC-HQ-60-17-C-0007
 !
-submodule(string_functions_interface) string_functions_implementation
+submodule(string_functions_m) string_functions_s
   implicit none
 
 contains

--- a/src/units_m.f90
+++ b/src/units_m.f90
@@ -4,7 +4,7 @@
 !     "Multi-Dimensional Physics Implementation into Fuel Analysis under Steady-state and Transients (FAST)",
 !     contract # NRC-HQ-60-17-C-0007
 !
-module units_interface
+module units_m
   !! author: Damian Rouson
   !! date: 9/9/2019
   !!

--- a/src/units_s.f90
+++ b/src/units_s.f90
@@ -4,7 +4,7 @@
 !     "Multi-Dimensional Physics Implementation into Fuel Analysis under Steady-state and Transients (FAST)",
 !     contract # NRC-HQ-60-17-C-0007
 !
-submodule(units_interface) units_implementation
+submodule(units_m) units_s
     use assert_m, only : assert
     implicit none
 
@@ -123,4 +123,4 @@ submodule(units_interface) units_implementation
             ratio%system = merge(numerator%system,dimensionless,any(ratio%exponents_/=0))
         end procedure
 
-end submodule units_implementation
+end submodule units_s

--- a/tests/data_partition_test.f90
+++ b/tests/data_partition_test.f90
@@ -5,7 +5,7 @@ module data_partition_test
    use vegetables, only: &
      result_t, example_t, input_t, integer_input_t, test_item_t, & ! types
      describe, it, assert_equals, assert_that  ! functions
-   use data_partition_interface, only : data_partition_t
+   use data_partition_m, only : data_partition_t
    use iso_fortran_env, only : real64
    implicit none
 

--- a/tests/main.f90
+++ b/tests/main.f90
@@ -9,8 +9,8 @@ contains
                 data_partition_data_partition => test_data_partition
         use formats_test, only: &
                 formats_object => test_object
-        use object_interface_test, only: &
-                object_interface_object => test_object
+        use object_m_test, only: &
+                object_m_object => test_object
         use user_defined_collectives_test, only: &
                 user_defined_collectives_co_all => test_co_all
         use vegetables, only: test_item_t, test_that, run_tests
@@ -20,7 +20,7 @@ contains
 
         individual_tests(1) = data_partition_data_partition()
         individual_tests(2) = formats_object()
-        individual_tests(3) = object_interface_object()
+        individual_tests(3) = object_m_object()
         individual_tests(4) = user_defined_collectives_co_all()
         tests = test_that(individual_tests)
 

--- a/tests/object_interface_test.f90
+++ b/tests/object_interface_test.f90
@@ -1,11 +1,11 @@
-module object_interface_test
+module object_m_test
    !! author: Damian Rouson
    !!
    !! summary: verify object pattern asbtract parent
    use vegetables, only: &
      result_t, input_t, integer_input_t, test_item_t, &   ! types
      describe, it, assert_equals, assert_that, assert_not ! functions
-   use object_interface, only : object_t
+   use object_m, only : object_t
    implicit none
 
    private
@@ -67,11 +67,11 @@ contains
         iomsg = ""
       case default
         iostat = -1
-        iomsg = "object_interface_test: subject%write_formatted iotype received unsupported iotype " // iotype
+        iomsg = "object_m_test: subject%write_formatted iotype received unsupported iotype " // iotype
     end select
 
     associate( unused => v_list)
     end associate
   end subroutine
 
-end module object_interface_test
+end module object_m_test


### PR DESCRIPTION
This matches the naming convention across most or all other recent
releases of Sourcery/Archaeologic software.