### PR TITLE
Print test subject before printing results

### DIFF
--- a/src/test_result_m.f90
+++ b/src/test_result_m.f90
@@ -17,7 +17,7 @@ module test_result_m
 
   interface test_result_t
 
-    pure module function construct(description, passed) result(test_result)
+    elemental module function construct(description, passed) result(test_result)
       !! The result is a test_result_t object with the components defined by the dummy arguments
       implicit none
       character(len=*), intent(in) :: description

--- a/src/test_s.f90
+++ b/src/test_s.f90
@@ -6,9 +6,9 @@ contains
   module procedure report
     integer i
 
+    print *
+    print *, test%subject()
     associate(test_results => test%results())
-      print *
-      print *, test%subject()
       associate(num_tests => size(test_results))
         tests = tests + num_tests
         do i=1,num_tests

--- a/test/main.f90
+++ b/test/main.f90
@@ -3,12 +3,14 @@ program main
   use data_partition_test, only : data_partition_test_t
   use object_m_test, only : object_test_t  
   use formats_test, only : formats_test_t  
+  use test_result_test, only : test_result_test_t  
   implicit none
 
   type(collectives_test_t) collectives_test
   type(data_partition_test_t) data_partition_test
   type(formats_test_t) formats_test
   type(object_test_t) object_test
+  type(test_result_test_t) test_result_test
 
   integer :: passes=0, tests=0
 
@@ -16,8 +18,8 @@ program main
   call collectives_test%report(passes, tests)
   call object_test%report(passes, tests)
   call formats_test%report(passes, tests)
+  call test_result_test%report(passes, tests)
 
   print *
   print *,"_________ In total, ",passes," of ",tests, " tests pass. _________"
-
 end program

--- a/test/test_result_test.f90
+++ b/test/test_result_test.f90
@@ -1,0 +1,40 @@
+module test_result_test
+  !! Verify object pattern asbtract parent
+  use test_m, only : test_t, test_result_t
+  use test_result_m, only : test_result_t
+  implicit none
+
+  private
+  public :: test_result_test_t
+
+  type, extends(test_t) :: test_result_test_t
+  contains
+    procedure, nopass :: subject
+    procedure, nopass :: results
+  end type
+
+contains
+
+  pure function subject() result(specimen)
+    character(len=:), allocatable :: specimen
+    specimen = "The test_result_t type" 
+  end function
+
+  function results() result(test_results)
+    type(test_result_t), allocatable :: test_results(:)
+
+    test_results = [ &
+      test_result_t("constructs and array of test_result_t objects elmentally", check_array_result_construction()) &
+    ]
+  end function
+
+  pure function check_array_result_construction() result(passed)
+    type(test_result_t), allocatable :: test_results(:)
+    logical passed
+
+    test_results = test_result_t(["foo","bar"], [.true.,.false.])
+
+    passed = size(test_results)==2
+  end function
+
+end module test_result_test


### PR DESCRIPTION
This ensures that the test subject shows even if the test crashes.