### PR TITLE
fix(command_line): handle multiple arguments

### DIFF
--- a/src/sourcery/command_line_s.f90
+++ b/src/sourcery/command_line_s.f90
@@ -43,6 +43,8 @@ contains
     flag_search: &
     do argnum = 1,command_argument_count()
 
+      if (allocated(arg)) deallocate(arg)
+
       call get_command_argument(argnum, length=arglen)
       allocate(character(len=arglen) :: arg)
       call get_command_argument(argnum, arg)


### PR DESCRIPTION
Deallocate flag value before reallocating.