### PR TITLE
feat(data_partition): make last/first arg optional

### DIFF
--- a/src/sourcery/data_partition_m.f90
+++ b/src/sourcery/data_partition_m.f90
@@ -28,14 +28,14 @@ module data_partition_m
     pure module function first(image_number) result(first_index)
       !! the result is the first identification number owned by the executing image
       implicit none
-      integer, intent(in) :: image_number
+      integer, intent(in), optional :: image_number
       integer first_index
     end function
 
     pure module function last(image_number) result(last_index)
       !! the result is the last identification number owned by the executing image
       implicit none
-      integer, intent(in) :: image_number
+      integer, intent(in), optional :: image_number
       integer last_index
     end function
 

--- a/src/sourcery/data_partition_s.f90
+++ b/src/sourcery/data_partition_s.f90
@@ -14,13 +14,29 @@ contains
   end procedure
 
   module procedure first
+    integer image
+
     call assert( allocated(bin), "data_partition_s(first): allocated(bin)")
-    first_index = bin(image_number)%first()
+
+    if (present(image_number)) then
+      image = image_number
+    else
+      image = this_image()
+    end if
+    first_index = bin(image)%first()
   end procedure
 
   module procedure last
+    integer image
+
     call assert( allocated(bin), "data_partition_s(last): allocated(bin)")
-    last_index = bin(image_number)%last()
+
+    if (present(image_number)) then
+      image = image_number
+    else
+      image = this_image()
+    end if
+    last_index = bin(image)%last()
   end procedure
 
   module procedure gather_real32_1D_array

--- a/test/data_partition_test.f90
+++ b/test/data_partition_test.f90
@@ -32,6 +32,7 @@ contains
       associate( my_first=>partition%first(me), my_last=>partition%last(me) )
         test_results = [ &
           test_result_t("partitioning data in nearly even blocks", verify_block_partitioning()), &
+          test_result_t("default image_number is this_image()", verify_default_image_number()), &
           test_result_t("partitioning all data across all images without data loss", verify_all_particles_partitioned()), &
           test_result_t("gathering a 1D real array onto all images", verify_all_gather_1D_real_array()), &
           test_result_t("gathering dimension 1 of 2D real array onto all images witout dim argument", &
@@ -61,6 +62,16 @@ contains
           end associate
         end associate
       end associate
+    end associate
+  end function
+
+  function verify_default_image_number() result(test_passes)
+    !! Verify that the first and last functions assume image_number == this_image() if image_number is not  present
+    type(data_partition_t) partition
+    logical test_passes
+
+    associate( me=>this_image() )
+      test_passes = partition%first() == partition%first(me) .and.partition%last() == partition%last(me)
     end associate
   end function
 


### PR DESCRIPTION
With this commit, the `data_partition_t` type-bound procedures `first()` and `last()` no longer require an argument.  Not passing an argument is treated equivalently to passing `this_image()` as the argument.