### PR TITLE
Disambiguate get_json_value

### DIFF
--- a/src/sourcery/sourcery_string_m.f90
+++ b/src/sourcery/sourcery_string_m.f90
@@ -76,7 +76,7 @@ module sourcery_string_m
       type(string_t) :: value_
     end function
 
-    elemental module function get_json_integer(self, key, mold) result(value_)
+    pure module function get_json_integer(self, key, mold) result(value_)
       implicit none
       class(string_t), intent(in) :: self, key
       integer, intent(in) ::  mold

--- a/src/sourcery/sourcery_string_m.f90
+++ b/src/sourcery/sourcery_string_m.f90
@@ -18,7 +18,7 @@ module sourcery_string_m
     generic :: operator(==)   => string_t_eq_string_t, string_t_eq_character, character_eq_string_t
     generic :: assignment(= ) => assign_string_t_to_character, assign_character_to_string_t
     generic :: get_json_value =>     get_json_integer_array, get_json_logical, get_json_integer, get_json_string, get_json_real
-    procedure ::                     get_json_integer_array, get_json_logical, get_json_integer, get_json_string, get_json_real
+    procedure, private            :: get_json_integer_array, get_json_logical, get_json_integer, get_json_string, get_json_real
     procedure, private            :: string_t_ne_string_t, string_t_ne_character
     procedure, private            :: string_t_eq_string_t, string_t_eq_character
     procedure, private            :: assign_character_to_string_t


### PR DESCRIPTION
This eliminates an ambiguity in generic resolution caused by an `elemental` `get_integer_value` binding clobbering a specific `get_integer_array_value` binding.