### PR TITLE
Feature: file_t constructor now allows non-allocatable string_t array actual arguments

### DIFF
--- a/src/sourcery/sourcery_file_m.f90
+++ b/src/sourcery/sourcery_file_m.f90
@@ -23,7 +23,7 @@ module sourcery_file_m
 
     pure module function construct(lines) result(file_object)
       implicit none
-      type(string_t), intent(in), allocatable :: lines(:)
+      type(string_t), intent(in) :: lines(:)
       type(file_t) file_object
     end function
 


### PR DESCRIPTION
This pull request removes the `allocatable` attribute from the `file_t` constructor function that has a `string_t` array dummy argument. Doing so facilitates passing an expression actual argument.